### PR TITLE
cap upper version of StatPlots

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7-beta
 DataFrames 0.11.6
 Plots 0.17.2
-StatPlots 0.7.2
+StatPlots 0.7.2 0.8.1
 OffsetArrays 0.6.0
 GR 0.31.0


### PR DESCRIPTION
This package appears to break when we reenable precompilation on StatPlots in 0.8.2 - see https://github.com/JuliaLang/METADATA.jl/pull/19526