### PR TITLE
Transform to recipe

### DIFF
--- a/src/GingrichStocking_chart.jl
+++ b/src/GingrichStocking_chart.jl
@@ -1,132 +1,71 @@
 #Gingrich stocking chart calculated using the original upland oak parameters
 #for more information see:http://oak.snr.missouri.edu/silviculture/tools/gingrich.html
 
-using Plots
-using StatPlots; gr()
-using DataFrames
+using RecipesBase
 
-function gingrich_chart(tpa_in,basal_area_in)
-#define parameters
-a =[-0.0507, 0.1698, 0.0317]
-b =[0.175, 0.205, 0.06]
+amd_convert(qmd) = -0.259 + 0.973qmd
+get_tpa(j, i, a) = (1*j*10)/(a[1]+a[2]*amd_convert(i)+a[3]*i^2)
 
-ba_ticks=collect(0:20:160)
-tpa_ticks=collect(0:50:450)
-
-#QMD lines
-dia = [7, 8, 10, 12, 14, 16, 18, 20, 22]
-#stocking percent horizontal lines
-stk_percent=collect(20:10:110)
-
-#function to convert between artihmetic and quadratic mean
-#need to add this to test?
-function amd_convert(qmd)
-  amd=-0.259+0.973*qmd
+function stklines(stk, dia, a)
+  tpa = get_tpa.(stk', dia, Ref(a))
+  ba = pi * (dia ./ 24).^2 .* tpa
+  tpa, ba
 end
 
-#function to draw stocking lines...needs work
-function make_stklines(stk,dia)
-  BA=Float64[]
-  TPA=Float64[]
-  STK=Int64[]
-  for j in stk
-    for i in dia
-      tpa=(1*j*10)/(a[1]+a[2]*amd_convert(i)+a[3]*i^2)
-      ba=pi*(i/24)^2*tpa
-      push!(TPA,tpa)
-      push!(BA,ba)
-      push!(STK,j)
-    end
+@userplot gingrich_chart
+@recipe function f(dat::gingrich_chart)
+
+  #define parameters
+  a = [-0.0507, 0.1698, 0.0317]
+  b = [0.175, 0.205, 0.06]
+  ba_ticks= 0:20:160
+  tpa_ticks= 0:50:450
+  #QMD lines
+  dia = [7, 8, 10, 12, 14, 16, 18, 20, 22]
+  #stocking percent horizontal lines
+  stk_percent= 20:10:110
+
+  # plot attributes
+  xlabel --> "Trees Per Acre"
+  ylabel --> "Basal Area (sq ft./acre)"
+  xticks --> 0:50:450
+  yticks --> 0:20:200
+  legend := false
+  primary := false
+
+  tpa, ba = stklines(stk_percent, dia, a)
+
+  # horizontal lines
+  @series begin
+    linecolor := :black
+    tpa, ba
   end
-return DataFrame(TPA=TPA,BA=BA,STK=STK)
-end
 
-df2=make_stklines(stk_percent,dia)
-
-#function to draw QMD lines
-function make_lines(qmd)
-  BA=Float64[]
-  TPA=Float64[]
-  QMD=Int[]
-  for i in stk_percent
-    tpa= 1*(i*10)/(a[1]+a[2]*amd_convert(qmd)+a[3]*qmd^2)
-    ba=pi*(qmd/24)^2*tpa
-    push!(TPA,tpa)
-    push!(BA,ba)
-    push!(QMD,qmd)
+  # vertical lines
+  @series begin
+    linecolor := :black
+    tpa', ba'
   end
-return DataFrame(TPA=TPA,BA=BA,QMD=QMD)
-end
 
-#from stack overflow, make dataframe containing all QMD lines
-df=DataFrame(TPA=Float64[],BA=Float64[],QMD=Int[])
-for i in dia
-  append!(df,make_lines(i))
-end
-
-#equation for A-line
-A_line=make_stklines(100,dia)
-
-stk_percent
-function make_bline(qmd)
-  STK=Int64[]
-  BA=Float64[]
-  TPA=Float64[]
-  QMD=Int[]
-  for i in stk_percent
-    tpa= 1*(i*10)/(b[1]+b[2]*amd_convert(qmd)+b[3]*qmd^2)
-    ba=pi*(qmd/24)^2*tpa
-    push!(STK,i)
-    push!(TPA,tpa)
-    push!(BA,ba)
-    push!(QMD,qmd)
+  # upper red line
+  @series begin
+    linecolor := :red
+    stklines([100], dia, a)
   end
-return DataFrame(STK=STK,TPA=TPA,BA=BA,QMD=QMD)
+
+  # lower red line
+  @series begin
+    linecolor := :red
+    stklines([100], dia, b)
+  end
+
+  # the point and the annotations
+  @series begin
+    primary := true
+    seriestype := :scatter
+    annotations := (100:38:442, 20:10:110, ["$i%" for i in 20:10:110])
+
+    a,b = dat.args
+    [a], [b]
+  end
 end
-
-df3=DataFrame(STK=Int64[],TPA=Float64[],BA=Float64[],QMD=Int[])
-for i in dia
-  append!(df3,make_bline(i))
-end
-df3
-B_line=df3[df3[:STK] .== 100,:] # super hacky work around for now...
-
-
-@df df plot(:TPA,:BA,group=:QMD,color=:black,legend=false)
-@df df2 plot!(:TPA,:BA,group=:STK,color=:black,legend=false)
-@df A_line plot!(:TPA,:BA,group=:STK,color=:red,legend=false)
-@df B_line plot!(:TPA,:BA,group=:STK,color=:red,
-xlabel="Trees Per Acre",
-ylabel="Basal Area (sq ft./acre)",
-xticks=collect(0:50:450),
-yticks=collect(0:20:200),
-legend=false)
-#text coords approximated, text() is a plot thing that wraps into type, so you can passs font and text parameters
-annotate!([(100, 19, text("20%",10)),
-           (138, 29, text("30%",10)),
-           (174, 38, text("40%",10)),
-           (214, 49, text("50%",10)),
-           (254, 60, text("60%",10)),
-           (290, 69, text("70%",10)),
-           (324, 79, text("80%",10)),
-           (364, 89, text("90%",10)),
-           (404, 99, text("100%",10)),
-           (440, 112, text("110%",10))
-           ])
-scatter!((tpa_in,basal_area_in))
-
-#####################
-#deprecated when dataframes reboot came out? had to switch to @df syntax
-# plot(df,:TPA,:BA,group=:QMD,color=:black)
-# plot!(df2,:TPA,:BA,group=:STK,color=:black,
-# xlabel="Trees Per Acre",
-# ylabel="Basal Area (sq ft./acre)",
-# xticks=collect(0:50:450),
-# yticks=collect(0:20:200),
-# legend=false)
-# scatter!((tpa_in,basal_area_in))
-#####################
-
-end #end function
-
-gingrich_chart(400,80)


### PR DESCRIPTION
Here, as promised, a demonstration of how plots can be expressed as recipes. Here are notes on what I've done:

1. I've created a recipe rather than a plot call, so you can drop the dep on Plots and StatPlots. The type here is a `userplot` recipe, which behaves the same way as the function you had before, i.e. you call it `gingrich_chart(400, 800)`.
2. It's an R-ism to first fill a dataframe with all the data, then plot it. Just generate the data and send them to the plot immediately. The way to add now plot elements is to use the `@series` macro.
3. Using Julia's broadcasting ability, you can express the tpa-generating code very concisely. This has the added advantage of returning a Matrix from two input Vectors - and in Plots, Matrix columns are individual series.
4. This also means I can plot the qmd-style lines simply by transposing the matrices.
5. No need to constantly `collect`. All uses of it here were superfluous.
6. I've made the annotations code more compact.

The only thing that is NOT successful is the font size of the annotations. This can not yet be changed in RecipesBase - but we're working on that!

![gingrich](https://user-images.githubusercontent.com/8429802/48805638-24f78780-ed18-11e8-88fa-86fe14c0d319.png)

